### PR TITLE
use 'fixed = TRUE' where possible

### DIFF
--- a/R/AddProbDup.R
+++ b/R/AddProbDup.R
@@ -146,7 +146,7 @@ AddProbDup <- function(pdup, db, addto = c("I", "II"), max.count = 30) {
       pdup[[i]] <- as.data.table(pdup[[i]])
       pdup[[i]] <- subset(pdup[[i]], COUNT <= max.count)
       pdup[[i]][, TYPE := NULL]
-      pdup[[i]] <- pdup[[i]][, list(PRIM_ID = unlist(strsplit(ID, ", " ))),
+      pdup[[i]] <- pdup[[i]][, list(PRIM_ID = unlist(strsplit(ID, ", ", fixed = TRUE))),
                              by = list(SET_NO, IDKW, ID)]
       if (method == "b" | method == "c") {
         if (addto == "I") {
@@ -161,9 +161,9 @@ AddProbDup <- function(pdup, db, addto = c("I", "II"), max.count = 30) {
       # Aggregate according to ID
       pdup[[i]] <- pdup[[i]][, list(SET_NO = paste0(sort(unique(SET_NO)),
                                                     collapse = ", "),
-                                    IDKW = paste0(sort(unique(unlist(strsplit(IDKW, ", ")))),
+                                    IDKW = paste0(sort(unique(unlist(strsplit(IDKW, ", ", fixed = TRUE)))),
                                                   collapse = ", "),
-                                    ID = paste0(sort(unique(unlist(strsplit(ID, ", ")))),
+                                    ID = paste0(sort(unique(unlist(strsplit(ID, ", ", fixed = TRUE)))),
                                                 collapse = ", ")), by = PRIM_ID]
       setkey(pdup[[i]], PRIM_ID)
       setcolorder(pdup[[i]], c("PRIM_ID", "SET_NO", "ID", "IDKW"))

--- a/R/DataClean.R
+++ b/R/DataClean.R
@@ -102,13 +102,13 @@ DataClean <- function(x, fix.comma = TRUE, fix.semcol = TRUE, fix.col = TRUE,
     # Convert all strings to upper case
     x <- vapply(x, FUN = toupper, FUN.VALUE = "character")
     if (fix.comma) {
-    x <- gsub(pattern = ",", replacement = " ", x)  # Replace "," by space
+    x <- gsub(pattern = ",", replacement = " ", x, fixed = TRUE)  # Replace "," by space
     }
     if (fix.semcol) {
-    x <- gsub(pattern = ";", replacement = " ", x)  # Replace ";" by space
+    x <- gsub(pattern = ";", replacement = " ", x, fixed = TRUE)  # Replace ";" by space
     }
     if (fix.col) {
-    x <- gsub(pattern = ":", replacement = " ", x)  # Replace ":" by space
+    x <- gsub(pattern = ":", replacement = " ", x, fixed = TRUE)  # Replace ":" by space
     }
     # Replace brackets by space
     if (fix.bracket) {

--- a/R/DisProbDup.R
+++ b/R/DisProbDup.R
@@ -152,7 +152,7 @@ DisProbDup <- function(pdup, combine = c("F", "P", "S")) {
   for (i in 1:N) {
     if (!is.null(pdup[[i]])) {
       # Get and cast the disjoint sets by PRIM_ID
-      idlist <- strsplit(pdup[[i]]$ID, ", ")
+      idlist <- strsplit(pdup[[i]]$ID, ", ", fixed = TRUE)
       idcomb <- do.call("rbind", lapply(idlist, embed, 2))
       gg <- graph.edgelist(idcomb, directed = FALSE)
       disidlist <- split(V(gg)$name, clusters(gg)$membership)
@@ -169,7 +169,7 @@ DisProbDup <- function(pdup, combine = c("F", "P", "S")) {
       pdup[[i]] <- as.data.table(pdup[[i]])
       #pdup[[i]] <- data.table(pdup[[i]])
       pdup[[i]] <- pdup[[i]][, .(unlist(strsplit(IDKW, ", ", TRUE))), by = TYPE][,
-                               .(IDKW = toString(sort(unique(unlist(strsplit(V1, ", ")))))),
+                               .(IDKW = toString(sort(unique(unlist(strsplit(V1, ", ", fixed = TRUE)))))),
                                .(TYPE, ID = gsub(":.*", "", V1))]
       pdup[[i]] <- unique(pdup[[i]])
       setkey(pdup[[i]], ID)

--- a/R/DoubleMetaphone.R
+++ b/R/DoubleMetaphone.R
@@ -65,7 +65,7 @@ DoubleMetaphone <- function(str) {
     stop("str is not a character vector")
   }
   if (any(grepl("NON_ASCII",
-                iconv(str, "latin1", "ASCII", sub = "NON_ASCII"))) == TRUE) {
+                iconv(str, "latin1", "ASCII", sub = "NON_ASCII"), fixed = TRUE)) == TRUE) {
     str <- iconv(str, to = "ASCII//TRANSLIT")
     warning("Non-ASCII characters were encountered.")
   }

--- a/R/KWIC.R
+++ b/R/KWIC.R
@@ -130,7 +130,7 @@ KWIC <- function(x, fields, min.freq = 10) {
   # Create KWIC index using data.table
   K <-  as.list(rep(NA, length(fields)))
   for (i in 1:(length(fields))) {
-    K[[i]] <-  x[, list(KEYWORD = unlist(strsplit(get(fields[i]), " ")),
+    K[[i]] <-  x[, list(KEYWORD = unlist(strsplit(get(fields[i]), " ", fixed = TRUE)),
                         FIELD = fields[i]),
                  by = list(PRIM_ID = get(fields[1]), KWIC)]
     K[[i]] <- K[[i]][!is.na(K[[i]]$KEYWORD), ]
@@ -141,8 +141,8 @@ KWIC <- function(x, fields, min.freq = 10) {
   set(KWIC, which(is.na(KWIC[["KEYWORD"]])), "KEYWORD", "")
   KWIC <- setkey(KWIC, KEYWORD)
   # Remove all '\' from KWIC
-  KWIC[, KWIC := gsub(pattern = "([\\])", replacement = "", x = KWIC)]
-  KWIC[, KEYWORD := gsub(pattern = "([\\])", replacement = "", x = KEYWORD)]
+  KWIC[, KWIC := gsub(pattern = "\\", replacement = "", x = KWIC, fixed = TRUE)]
+  KWIC[, KEYWORD := gsub(pattern = "\\", replacement = "", x = KEYWORD, fixed = TRUE)]
   # Remove records with blank keywords
   KWIC <- subset(KWIC, KEYWORD != "")
   # Remove duplicate records
@@ -154,16 +154,16 @@ KWIC <- function(x, fields, min.freq = 10) {
   KWIC[, KEYWORD := gsub(pattern = "([.|()\\^{}+$*?]|\\[|\\])",
                          replacement = "\\\\\\1", x = KEYWORD)]
   # Highlight keywords in KWIC
-  KWIC[, KWIC := mapply(gsub, pattern = paste0(" ", KEYWORD, " "),
+  KWIC[, KWIC := mapply(gsub, fixed = TRUE, pattern = paste0(" ", KEYWORD, " "),
                         replacement = paste0(" <<", KEYWORD, ">> "), KWIC)]
   KWIC[, KWIC := gsub("^\\s+|\\s+$", "", KWIC)]
   # Unescape all Regex special characters
   KWIC[, KEYWORD := gsub(pattern = "\\\\(.)", replacement = "\\1", x = KEYWORD)]
   # Split KWIC
   KWIC[, c("KWIC_L", "KW1") := do.call(rbind.data.frame,
-                                 stri_split_fixed(KWIC, "<<", 2))][]
+                                 stri_split_fixed(KWIC, "<<", 2))]
   KWIC[, c("KWIC_KW", "KWIC_R") := do.call(rbind.data.frame,
-                                stri_split_fixed(KW1, ">>", 2))][]
+                                stri_split_fixed(KW1, ">>", 2))]
   cols <- c("KWIC_L", "KWIC_KW", "KWIC_R")
   KWIC[, (cols) := lapply(.SD, as.character), .SDcols = cols]
   KWIC[, KW1 := NULL]
@@ -176,7 +176,7 @@ KWIC <- function(x, fields, min.freq = 10) {
   #KWICIndex[[1]] <- as.data.frame(KWIC)
   KWICIndex[[1]] <- setDF(KWIC)
   # Get keyword freq
-  kwf <- as.data.frame(table(KWIC$KEYWORD))
+  kwf <- as.data.frame(table(KWIC$KEYWORD), stringsAsFactors = FALSE)
   kwf <- subset(kwf, Freq > min.freq)
   kwf <- kwf[order(-kwf$Freq), ]
   rownames(kwf) <- NULL

--- a/R/ProbDup.R
+++ b/R/ProbDup.R
@@ -372,9 +372,9 @@ ProbDup <- function (kwic1, kwic2 = NULL, method = c("a", "b", "c"),
   kwicQ[, IDKW := paste(PRIM_ID, KEYWORD, sep = ":")]
   if (method == "a" | method == "b") {
     kwicQ <- kwicQ[, list(PRIM_ID = paste0(setdiff(sort(unique(unlist(strsplit(get("PRIM_ID"),
-                                                                               split = ", ")))), ""), collapse = ", "),
+                                                                               split = ", ", fixed = TRUE)))), ""), collapse = ", "),
                           IDKW = paste0(setdiff(sort(unique(unlist(strsplit(get("IDKW"),
-                                                                            split = ", ")))), ""), collapse = ", ")),
+                                                                            split = ", ", fixed = TRUE)))), ""), collapse = ", ")),
                    by = "KEYWORD"]
     # Id the chunks in kwic1
     M <- nrow(kwicQ)
@@ -398,9 +398,9 @@ ProbDup <- function (kwic1, kwic2 = NULL, method = c("a", "b", "c"),
     kwicS[, IDKW := paste(PRIM_ID, KEYWORD, sep = ":")]
     if (method == "b") {
       kwicS <- kwicS[, list(PRIM_ID = paste0(setdiff(sort(unique(unlist(strsplit(get("PRIM_ID"),
-                                                                                 split = ", ")))), ""), collapse = ", "),
+                                                                                 split = ", ", fixed = TRUE)))), ""), collapse = ", "),
                             IDKW = paste0(setdiff(sort(unique(unlist(strsplit(get("IDKW"),
-                                                                              split = ", ")))), ""), collapse = ", ")),
+                                                                              split = ", ", fixed = TRUE)))), ""), collapse = ", ")),
                      by = "KEYWORD"]
     }
     N <- nrow(kwicS)
@@ -410,9 +410,9 @@ ProbDup <- function (kwic1, kwic2 = NULL, method = c("a", "b", "c"),
     if (method == "c") {
       kwicQ <- as.data.table(rbind(kwicQ, kwicS))
       kwicQ <- kwicQ[, list(PRIM_ID = paste0(setdiff(sort(unique(unlist(strsplit(get("PRIM_ID"),
-                                                                                 split = ", ")))), ""), collapse = ", "),
+                                                                                 split = ", ", fixed = TRUE)))), ""), collapse = ", "),
                             IDKW = paste0(setdiff(sort(unique(unlist(strsplit(get("IDKW"),
-                                                                              split = ", ")))), ""), collapse = ", ")), by = "KEYWORD"]
+                                                                              split = ", ", fixed = TRUE)))), ""), collapse = ", ")), by = "KEYWORD"]
       M <- nrow(kwicQ)
       if (M > chunksize) {
         chunksize <- chunksize
@@ -642,9 +642,9 @@ FuzzyDup <- function(kwic1, kwic2, max.dist, useBytes,
   rm(ind_exactQ2)
   if ("FuzzydupIDKW2" %in% colnames(kwic1)) {
     kwic1[, FuzzydupIDKW := toString(unique(c(strsplit(FuzzydupIDKW,
-                                                       split = ", ")[[1]],
+                                                       split = ", ", fixed = TRUE)[[1]],
                                               strsplit(FuzzydupIDKW2,
-                                                       split = ", ")[[1]]))),
+                                                       split = ", ", fixed = TRUE)[[1]]))),
           by = IDKW]
     kwic1[, FuzzydupIDKW2 := NULL]
   }
@@ -789,7 +789,7 @@ SemanticDup <- function(kwic1, kwic2, syn, useBytes, method) {
   kwic1 <- dupsets(kwic1, "S", method = method)
   # Remove synsets with single/unique members
   kwic1 <- kwic1[!unlist(lapply(strsplit( gsub("*?\\[\\S+:", "", kwic1$IDKW),
-                                          split = ", "), function(x) length(unique(x)))) == 1, ]
+                                          split = ", ", fixed = TRUE), function(x) length(unique(x)))) == 1, ]
   return(kwic1)
 }
 
@@ -811,11 +811,11 @@ dupsets <- function(kwicout, type, method) {
       kwicout[, Ndup := NULL]
     }
     # Merge by PRIM_ID, then by ID, then add TYPE
-    kwicout <- kwicout[, list(ID = paste0(setdiff(sort(unique(unlist(strsplit(get(names(kwicout)[3]), split = ", ")))), ""),
+    kwicout <- kwicout[, list(ID = paste0(setdiff(sort(unique(unlist(strsplit(get(names(kwicout)[3]), split = ", ", fixed = TRUE)))), ""),
                                           collapse = ", "),
-                              IDKW = paste0(setdiff(sort(unique(unlist(strsplit(get(names(kwicout)[2]), split = ", ")))), ""),
+                              IDKW = paste0(setdiff(sort(unique(unlist(strsplit(get(names(kwicout)[2]), split = ", ", fixed = TRUE)))), ""),
                                             collapse = ", ")),
-                       by = "PRIM_ID"][, list(IDKW = paste0(sort(unique(unlist(strsplit(IDKW, split = ", ")))),
+                       by = "PRIM_ID"][, list(IDKW = paste0(sort(unique(unlist(strsplit(IDKW, split = ", ", fixed = TRUE)))),
                                                             collapse = ", "),
                                                      TYPE = type), by = "ID"]
     setkey(kwicout, NULL)

--- a/R/ViewProbDup.R
+++ b/R/ViewProbDup.R
@@ -287,7 +287,7 @@ ViewProbDup <- function(pdup, db1, db2 = NULL,
   if (!is.null(pdup[["DisjointDupicates"]])) {
     tryCatch(DisProbDup(pdup),
              warning = function(e) {
-               message(gsub("returned", "displayed", e$message))
+               message(gsub("returned", "displayed", e$message, fixed = TRUE))
              })
     pdup <- suppressWarnings(DisProbDup(pdup))
   } else {
@@ -298,7 +298,7 @@ ViewProbDup <- function(pdup, db1, db2 = NULL,
     if (dim(tstr[tstr$is.null == FALSE, ])[1] == 1) {
       tryCatch(DisProbDup(pdup),
       warning = function(e) {
-        message(gsub("returned", "displayed", e$message))
+        message(gsub("returned", "displayed", e$message, fixed = TRUE))
       })
       pdup <- suppressWarnings(DisProbDup(pdup))
     } else {
@@ -311,7 +311,7 @@ ViewProbDup <- function(pdup, db1, db2 = NULL,
                          extra.db1 = factor.db1, extra.db2 = factor.db2,
                          max.count, insert.blanks = FALSE),
            warning = function(e) {
-             message(gsub("merged", "used", e$message))
+             message(gsub("merged", "used", e$message, fixed = TRUE))
            })
   sets <- suppressWarnings(ReviewProbDup(pdup, db1, db2,
                                          extra.db1 = factor.db1,

--- a/R/print.ProbDup.R
+++ b/R/print.ProbDup.R
@@ -33,11 +33,11 @@ print.ProbDup <- function(x, ...) {
   attributes(x) <- append(attributes(x), attr[2:4])
   m <- data.frame(`No. of Sets` = sapply(x, function(x) dim(x)[1]),
                   `No. of Records` = sapply(x,
-                                            function(x) length(unique(unlist(strsplit(x$ID, split = ", "))))))
+                                            function(x) length(unique(unlist(strsplit(x$ID, split = ", ", fixed = TRUE))))))
   Total <- as.character(colSums(m))
   Total[2] <- paste(Total[2], "(Distinct:",
                     length(unique(unlist(lapply(x,
-                                                function(x) unlist(strsplit(x$ID, split = ", ")))))),
+                                                function(x) unlist(strsplit(x$ID, split = ", ", fixed = TRUE)))))),
                     ")", sep = "")
   m <- rbind(m, Total = Total)
   cat(paste("Method : ", attributes(x)$method, "\n", sep = ""))


### PR DESCRIPTION
I was poking around in this repo some, figured I'd submit this. The majority of this PR just adds arg `fixed = TRUE` wherever possible, which is an easy way to get a small speed boost from functions `strsplit()`, `grepl()`, and `gsub()`.

The only other edit is to add arg `stringsAsFactors = TRUE` to the call to `as.data.frame()` in line 179 of `KWIC.R` (see [here](https://github.com/aravind-j/PGRdup/blob/master/R/KWIC.R#L179) ). Without this arg, variable `Var1` from `table()` ends up as a factor, and when you subset `kwf` in line 180, that variable holds onto all of the levels that existed prior to subsetting, which makes the final data frame `kwf` a much larger object than it needs to be.

Let me know if you want anything tweaked, I'm happy to make edits if need be.